### PR TITLE
Issue 372: Crash in onCreateOptionsMenu on Nexus 7

### DIFF
--- a/src/com/keepassdroid/EntryActivity.java
+++ b/src/com/keepassdroid/EntryActivity.java
@@ -281,7 +281,7 @@ public class EntryActivity extends LockCloseActivity {
 		menu.add(0, MENU_GOTO_URL, 0, R.string.menu_url);
 		menu.findItem(MENU_GOTO_URL).setIcon(android.R.drawable.ic_menu_upload);
 		
-		if ( mEntry.getUrl().length() == 0 ) {
+		if ( mEntry.getUrl() == null || mEntry.getUrl().length() == 0 ) {
 			// disable button if url is not available
 			menu.findItem(MENU_GOTO_URL).setEnabled(false);
 		}


### PR DESCRIPTION
Issue 372:  Crash in onCreateOptionsMenu on Nexus 7

Checking EntryActivity.onCreateOptionsMenu for a NullPointer,
which might be returned from PwEntry.getUrl().
