### PR TITLE
Trim whitespace from query strings

### DIFF
--- a/src/com/keepassdroid/search/SearchResults.java
+++ b/src/com/keepassdroid/search/SearchResults.java
@@ -58,7 +58,7 @@ public class SearchResults extends GroupBaseActivity {
 	}
 	
 	private void performSearch(String query) {
-		query(query);
+		query(query.trim());
 	}
 	
 	private void query(String query) {


### PR DESCRIPTION
Many predictive keyboards insert a space after you select a prediction. (Swiftkey and Swype do this).  

This simple patch trims the search query, removing whitespace from the start/end of the query string.

A search for "foo " will find, "foo.com", for instance.
