### PR TITLE
Fix NDK download URL.

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 Native library build instructions:
 1. Make sure you have the latest MIPS Android NDK installed: 
-   http://developer.mips.com/android/download-android-ndk/
+   https://developer.android.com/tools/sdk/ndk/index.html
 
 2. From KeePassDroid/jni, call prep_build.sh to download and unpack the crypto sources.
 


### PR DESCRIPTION
The current NDK URL in README returns 404.
I've fixed it as android.com's because it seems includes toolchains for MIPS.
