### PR TITLE
Allow other apps to send password and launch_immediately through an ACTION_VIEW intent

### DIFF
--- a/app/src/main/java/com/keepassdroid/Database.java
+++ b/app/src/main/java/com/keepassdroid/Database.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
+import android.util.Log;
 
 import com.keepassdroid.database.PwDatabase;
 import com.keepassdroid.database.PwDatabaseV3;
@@ -95,12 +96,14 @@ public class Database {
         try {
             is = UriUtil.getUriInputStream(ctx, uri);
         } catch (Exception e) {
+            Log.e("KPD", "Database::LoadData", e);
             throw ContentFileNotFoundException.getInstance(uri);
         }
 
         try {
             kfIs = UriUtil.getUriInputStream(ctx, keyfile);
         } catch (Exception e) {
+            Log.e("KPD", "Database::LoadData", e);
             throw ContentFileNotFoundException.getInstance(keyfile);
         }
         LoadData(ctx, is, password, kfIs, status, debug);

--- a/app/src/main/java/com/keepassdroid/PasswordActivity.java
+++ b/app/src/main/java/com/keepassdroid/PasswordActivity.java
@@ -494,7 +494,7 @@ public class PasswordActivity extends LockingActivity {
             retrieveSettings();
 
             if (launch_immediately)
-                loadDatabase(password, mDbUri);
+                loadDatabase(password, mKeyUri);
         }
     }
 }

--- a/app/src/main/java/com/keepassdroid/PasswordActivity.java
+++ b/app/src/main/java/com/keepassdroid/PasswordActivity.java
@@ -382,6 +382,8 @@ public class PasswordActivity extends LockingActivity {
                 else {
                     return R.string.error_can_not_handle_uri;
                 }
+                password = i.getStringExtra(KEY_PASSWORD);
+                launch_immediately = i.getBooleanExtra(KEY_LAUNCH_IMMEDIATELY, false);
 
             } else {
                 mDbUri = UriUtil.parseDefaultFile(i.getStringExtra(KEY_FILENAME));


### PR DESCRIPTION
With Android's (relatively) new content URI system, passing filenames or raw URIs around between apps doesn't always work. In particular, if the file is non-local (e.g. in Google Drive) then the receiving app will generally not have permission to open the file. The solution is to grant permission in the Intent by setting a flag. But this only works if the URI is passed as the Intent's data (i.e. not an extra). This patch extends Keepass Droid's handling of Intents which contain a URI as data (ACTION_VIEW intents) to also attempt to read password and launch_immediately flags from the intent, as it does for non-ACTION_VIEW intents.
