### PR TITLE
Keyfile in view intent

### DIFF
--- a/app/src/main/java/com/keepassdroid/Database.java
+++ b/app/src/main/java/com/keepassdroid/Database.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
+import android.util.Log;
 
 import com.keepassdroid.database.PwDatabase;
 import com.keepassdroid.database.PwDatabaseV3;
@@ -95,12 +96,14 @@ public class Database {
         try {
             is = UriUtil.getUriInputStream(ctx, uri);
         } catch (Exception e) {
+            Log.e("KPD", "Database::LoadData", e);
             throw ContentFileNotFoundException.getInstance(uri);
         }
 
         try {
             kfIs = UriUtil.getUriInputStream(ctx, keyfile);
         } catch (Exception e) {
+            Log.e("KPD", "Database::LoadData", e);
             throw ContentFileNotFoundException.getInstance(keyfile);
         }
         LoadData(ctx, is, password, kfIs, status, debug);

--- a/app/src/main/java/com/keepassdroid/PasswordActivity.java
+++ b/app/src/main/java/com/keepassdroid/PasswordActivity.java
@@ -494,7 +494,7 @@ public class PasswordActivity extends LockingActivity {
             retrieveSettings();
 
             if (launch_immediately)
-                loadDatabase(password, mDbUri);
+                loadDatabase(password, mKeyUri);
         }
     }
 }

--- a/app/src/main/java/com/keepassdroid/PasswordActivity.java
+++ b/app/src/main/java/com/keepassdroid/PasswordActivity.java
@@ -382,6 +382,8 @@ public class PasswordActivity extends LockingActivity {
                 else {
                     return R.string.error_can_not_handle_uri;
                 }
+                password = i.getStringExtra(KEY_PASSWORD);
+                launch_immediately = i.getBooleanExtra(KEY_LAUNCH_IMMEDIATELY, false);
 
             } else {
                 mDbUri = UriUtil.parseDefaultFile(i.getStringExtra(KEY_FILENAME));


### PR DESCRIPTION
This adds support for passing KeyFile as a URI in the ACTION_VIEW intent.

This allows third party applications, such as KeePass NFC, to pass read permissions for both the Database and Keyfile to KeePassDroid. The official way to do this is to pass the first Content URI in the Intent's data field, and additional URIs in the Intent's ClipData. (See [documentation for ClipData] (https://developer.android.com/reference/android/content/Intent.html#setClipData%28android.content.ClipData%29)). This is what KeePass NFC now does (or will do, when this pull request is integrated!)

Passing ClipData in Intents was added in API level 16, so the routine to access ClipData uses conditional execution with a fallback in the case of a lower API level.