### PR TITLE
use ACTION_OPEN_DOCUMENT, to avoid file not found error on android > 4.4

### DIFF
--- a/app/src/main/java/com/keepassdroid/fileselect/FileSelectActivity.java
+++ b/app/src/main/java/com/keepassdroid/fileselect/FileSelectActivity.java
@@ -25,6 +25,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.preference.PreferenceManager;
@@ -208,14 +209,20 @@ public class FileSelectActivity extends Activity {
 		browseButton.setOnClickListener(new View.OnClickListener() {
 			
 			public void onClick(View v) {
+				Intent i;
 				if (StorageAF.useStorageFramework(FileSelectActivity.this)) {
-					Intent i = new Intent(StorageAF.ACTION_OPEN_DOCUMENT);
+					i = new Intent(StorageAF.ACTION_OPEN_DOCUMENT);
 					i.addCategory(Intent.CATEGORY_OPENABLE);
 					i.setType("*/*");
 					startActivityForResult(i, OPEN_DOC);
 				}
 				else {
-					Intent i = new Intent(Intent.ACTION_GET_CONTENT);
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+						i = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+					} else {
+						i = new Intent(Intent.ACTION_GET_CONTENT);
+					}
+
 					i.addCategory(Intent.CATEGORY_OPENABLE);
 					i.setType("*/*");
 


### PR DESCRIPTION
the file:// URI for ACTION_GET_CONTENT returned by the os is only usable
until the application is closed. to make the 'default database' feature
work on android 4.4 and above , we need to use ACTION_OPEN_DOCUMENT, which
returns a permanent URI like content://....

this should fix some storage related issues, like #164