### PR TITLE
Add Multi Window support for Samsung devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,5 +106,6 @@
             android:theme="@style/NoTitleBar"></activity>
         <service android:name="com.keepassdroid.services.TimeoutService"></service>
         <meta-data android:name="com.a0soft.gphone.aTrackDog.webURL" android:value="http://keepassdroid.com" />
+        <meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />
     </application>
 </manifest> 


### PR DESCRIPTION
A single meta-data entry is enough to make KeepassDroid "Multi Window" aware on supported Samsung devices.

![screenshot_2017-06-23-20-43-46](https://user-images.githubusercontent.com/43441/27505145-f982fe66-5855-11e7-8a07-2c90be058b0d.png)

Thoroughly tested with similar [Termux pull request](https://github.com/termux/termux-app/pull/339).

Here's a signed release APK if anyone wants to test it: http://d.pr/f/QqwdB7
