### PR TITLE
Fingerprint authentication should enter database after saving password

### DIFF
--- a/app/src/main/java/com/keepassdroid/PasswordActivity.java
+++ b/app/src/main/java/com/keepassdroid/PasswordActivity.java
@@ -436,7 +436,7 @@ public class PasswordActivity extends LockingActivity implements FingerPrintHelp
                 .putString(getPreferenceKeyIvSpec(), ivSpec)
                 .commit();
         // and remove visual input to reset UI
-        passwordView.setText("");
+        confirmButton.performClick();
         confirmationView.setText(R.string.encrypted_value_stored);
     }
 


### PR DESCRIPTION
With the new fingerprint authentication when you save a password, it clears the field and you have to enter your fingerprint again to unlock the database. I think it would make more sense for the database to be entered after saving your password for the first timer.