### PR TITLE
Fixing issue where Search opens new task instead of using same task.

### DIFF
--- a/app/src/main/java/com/keepassdroid/GroupBaseActivity.java
+++ b/app/src/main/java/com/keepassdroid/GroupBaseActivity.java
@@ -289,7 +289,6 @@ public abstract class GroupBaseActivity extends LockCloseListActivity {
 		 */
 		if (Intent.ACTION_SEARCH.equals(intent.getAction())) {
 			int flags = intent.getFlags();
-			// We have to clear this bit (which search automatically sets) otherwise startActivityForResult will never work
 			flags &= ~Intent.FLAG_ACTIVITY_NEW_TASK;
 			intent.setFlags(flags);
 		}

--- a/app/src/main/java/com/keepassdroid/GroupBaseActivity.java
+++ b/app/src/main/java/com/keepassdroid/GroupBaseActivity.java
@@ -21,6 +21,7 @@ package com.keepassdroid;
 
 
 import android.content.ActivityNotFoundException;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.os.Bundle;
@@ -277,6 +278,23 @@ public abstract class GroupBaseActivity extends LockCloseListActivity {
 				displayMessage(GroupBaseActivity.this);
 			}
 		}
+	}
+
+	@Override
+	public void startActivityForResult(Intent intent, int requestCode, Bundle options) {
+		/*
+		 * ACTION_SEARCH automatically forces a new task. This occurs when you open a kdb file in
+		 * another app such as Files or GoogleDrive and then Search for an entry. Here we remove the
+		 * FLAG_ACTIVITY_NEW_TASK flag bit allowing search to open it's activity in the current task.
+		 */
+		if (Intent.ACTION_SEARCH.equals(intent.getAction())) {
+			int flags = intent.getFlags();
+			// We have to clear this bit (which search automatically sets) otherwise startActivityForResult will never work
+			flags &= ~Intent.FLAG_ACTIVITY_NEW_TASK;
+			intent.setFlags(flags);
+		}
+
+		super.startActivityForResult(intent, requestCode, options);
 	}
 	
 	public class AfterDeleteGroup extends OnFinish {


### PR DESCRIPTION
If you open KeePassDroid from a file in another app, the KeePassDroid:PasswordActivity opens in that Task. However, if you search the ACTION_SEARCH intent opens a new task putting the app in a weird state that has various bugs. The easy way to fix this is setting PasswordActivity to LaunchMode="singleTask" in AndroidManifest. The other option is to remove the FLAG_ACTIVITY_NEW_TASK intent flag bit on search allowing the search activity to stay in the current task. I've included the second option in this changeset.

Solution found here: https://stackoverflow.com/questions/4807879/android-onsearchrequested-callback-to-the-calling-activity/44943963#44943963