### PR TITLE
Password should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/entry_edit.xml
+++ b/app/src/main/res/layout/entry_edit.xml
@@ -121,6 +121,7 @@
 			  android:singleLine="true"
 			  android:layout_toLeftOf="@id/generate_button"
 			  android:hint="@string/hint_pass"
+			  android:importantForAccessibility="no"
 			  android:layout_alignTop="@id/generate_button"/>
 			<View android:id="@+id/divider_password"
 			  android:layout_below="@id/generate_button"
@@ -140,6 +141,7 @@
 			  android:typeface="monospace"
 			  android:singleLine="true"
 			  android:layout_below="@id/entry_confpassword_label"
+              android:importantForAccessibility="no"
 			  android:hint="@string/hint_conf_pass"/>
 			<View android:id="@+id/divider_confpassword"
 			  android:layout_below="@id/entry_confpassword"

--- a/app/src/main/res/layout/generate_password.xml
+++ b/app/src/main/res/layout/generate_password.xml
@@ -44,6 +44,7 @@
 		      android:ems="10"
 		      android:singleLine="true"
 		      android:typeface="monospace"
+              android:importantForAccessibility="no"
 		      android:hint="@string/hint_generated_password" />
 		    <Button android:id="@+id/generate_password_button"
 		      android:layout_width="fill_parent"

--- a/app/src/main/res/layout/password.xml
+++ b/app/src/main/res/layout/password.xml
@@ -61,6 +61,7 @@
 	  android:layout_toLeftOf="@+id/fingerprint"
 	  android:singleLine="true"
 	  android:inputType="textPassword"
+	  android:importantForAccessibility="no"
 	  android:hint="@string/hint_login_pass"/>
 
     <!-- added these 2 fingerprint related views -->

--- a/app/src/main/res/layout/set_password.xml
+++ b/app/src/main/res/layout/set_password.xml
@@ -26,6 +26,7 @@
 	  android:layout_height="wrap_content"
 	  android:inputType="textPassword"
 	  android:singleLine="true"
+	  android:importantForAccessibility="no"
 	  android:hint="@string/hint_pass"/>
 	<EditText android:id="@+id/pass_conf_password" 
 	  android:layout_width="fill_parent"
@@ -33,6 +34,7 @@
 	  android:layout_below="@id/pass_password"
 	  android:inputType="textPassword"
 	  android:singleLine="true"
+	  android:importantForAccessibility="no"
 	  android:hint="@string/hint_conf_pass"/>
 	<EditText android:id="@+id/pass_keyfile" 
 	  android:layout_width="fill_parent"


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service, can capture all user inputs. In this case, password, should be ignored for the accessibility service, so such attacks can not be happened.