### PR TITLE
Feature/resolve fingerprint in screen issues #326

### DIFF
--- a/app/src/main/java/com/keepassdroid/PasswordActivity.java
+++ b/app/src/main/java/com/keepassdroid/PasswordActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2009-2018 Brian Pellin.
- *     
+ *
  * This file is part of KeePassDroid.
  *
  *  KeePassDroid is free software: you can redistribute it and/or modify
@@ -24,7 +24,6 @@ import android.app.Activity;
 import android.app.backup.BackupManager;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
-import android.content.ContextWrapper;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
@@ -72,8 +71,6 @@ import com.keepassdroid.utils.EmptyUtils;
 import com.keepassdroid.utils.Interaction;
 import com.keepassdroid.utils.UriUtil;
 import com.keepassdroid.utils.Util;
-
-import org.spongycastle.util.Pack;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -237,8 +234,8 @@ public class PasswordActivity extends LockingActivity implements FingerPrintHelp
         // Clear the shutdown flag
         App.clearShutdown();
 
-        // checks if fingerprint is available, will also start listening for fingerprints when available
-        checkAvailability();
+        // checks if fingerprint is available, only starts listening for fingerprints when available & auto start configured
+        checkFingerprintAvailability(false);
     }
 
     private void retrieveSettings() {
@@ -279,6 +276,13 @@ public class PasswordActivity extends LockingActivity implements FingerPrintHelp
 
     // fingerprint related code here
     private void initForFingerprint() {
+        // when fingerprint is enabled but auto scanning is not you can start scanning by clicking the fingerprint view
+        fingerprintView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                checkFingerprintAvailability(true);
+            }
+        });
         fingerPrintHelper = new FingerPrintHelper(this, this);
         if (fingerPrintHelper.hasEnrolledFingerprints()) {
 
@@ -317,7 +321,8 @@ public class PasswordActivity extends LockingActivity implements FingerPrintHelp
                         messageId = R.string.scanning_fingerprint;
                     }
                     confirmationView.setText(messageId);
-                    mode = validInput ? toggleMode(Cipher.ENCRYPT_MODE) : toggleMode(Cipher.DECRYPT_MODE);
+                    boolean autoStartScanning = prefs.getBoolean(getString(R.string.fingerprint_autoscan_key), true);
+                    mode = validInput ? toggleMode(Cipher.ENCRYPT_MODE, autoStartScanning) : toggleMode(Cipher.DECRYPT_MODE, autoStartScanning);
 
                 }
             });
@@ -379,24 +384,24 @@ public class PasswordActivity extends LockingActivity implements FingerPrintHelp
         return PREF_KEY_IV_PREFIX + (mDbUri != null ? mDbUri.getPath() : "");
     }
 
-    private int toggleMode(final int newMode) {
+    private int toggleMode(final int newMode, final boolean startListening) {
         if (mode != newMode) {
             mode = newMode;
             switch (mode) {
                 case Cipher.ENCRYPT_MODE:
-                    fingerPrintHelper.initEncryptData();
+                    fingerPrintHelper.initEncryptData(startListening);
                     break;
                 case Cipher.DECRYPT_MODE:
                     final String ivSpecValue = prefsNoBackup.getString(getPreferenceKeyIvSpec(), null);
                     if (ivSpecValue != null) {
-                        fingerPrintHelper.initDecryptData(ivSpecValue);
+                        fingerPrintHelper.initDecryptData(ivSpecValue, startListening);
                     }
                     break;
             }
         }
         else {
             fingerPrintHelper.stopListening();
-            fingerPrintHelper.startListening();
+            if( startListening ) fingerPrintHelper.startListening();
         }
 
         return mode;
@@ -429,7 +434,7 @@ public class PasswordActivity extends LockingActivity implements FingerPrintHelp
         confirmationView.setVisibility(vis);
     }
 
-    private void checkAvailability() {
+    private void checkFingerprintAvailability(final boolean forceAutoStart) {
         // fingerprint not supported (by API level or hardware) so keep option hidden
         if (!fingerPrintHelper.isHardwareDetected()) {
             setFingerPrintVisibilty(View.GONE);
@@ -457,11 +462,16 @@ public class PasswordActivity extends LockingActivity implements FingerPrintHelp
                 confirmationView.setText(R.string.no_password_stored);
             }
             // all is set here so we can confirm to user and start listening for fingerprints
-            else {
+            if( forceAutoStart || prefs.getBoolean(getString(R.string.fingerprint_autoscan_key), true) ){
 
                 confirmationView.setText(R.string.scanning_fingerprint);
                 // listen for decryption by default
-                toggleMode(Cipher.DECRYPT_MODE);
+                toggleMode(Cipher.DECRYPT_MODE, true);
+            }
+            // config OK but no auto scanning enabled
+            else {
+
+                confirmationView.setText(R.string.fingerprint_autoscan_title);
             }
         }
     }

--- a/app/src/main/java/com/keepassdroid/fingerprint/FingerPrintHelper.java
+++ b/app/src/main/java/com/keepassdroid/fingerprint/FingerPrintHelper.java
@@ -155,7 +155,7 @@ public class FingerPrintHelper {
         return hasEnrolledFingerprints() && initOk;
     }
 
-    public void initEncryptData() {
+    public void initEncryptData(final boolean startListening) {
         cryptoInitOk = false;
 
         if (!isFingerprintInitialized()) {
@@ -165,11 +165,11 @@ public class FingerPrintHelper {
             return;
         }
         try {
-            initEncryptKey(false);
+            initEncryptKey(false, startListening);
         } catch (final InvalidKeyException invalidKeyException) {
             try {
                 fingerPrintCallback.onKeyInvalidated();
-                initEncryptKey(true);
+                initEncryptKey(true, startListening);
             } catch (InvalidKeyException e) {
                 fingerPrintCallback.onInvalidKeyException();
             } catch (Exception e) {
@@ -181,7 +181,10 @@ public class FingerPrintHelper {
 
     }
 
-    private void initEncryptKey(boolean deleteExistingKey) throws Exception {
+    private void initEncryptKey(
+            final boolean deleteExistingKey,
+            final boolean startListening) throws Exception {
+
         createNewKeyIfNeeded(deleteExistingKey);
         keyStore.load(null);
         final SecretKey key = (SecretKey) keyStore.getKey(ALIAS_KEY, null);
@@ -189,7 +192,7 @@ public class FingerPrintHelper {
         cryptoInitOk = true;
 
         stopListening();
-        startListening();
+        if( startListening ) startListening();
     }
 
     public void encryptData(final String value) {
@@ -216,7 +219,9 @@ public class FingerPrintHelper {
 
     }
 
-    public void initDecryptData(final String ivSpecValue) {
+    public void initDecryptData(
+            final String ivSpecValue,
+            final boolean startListening) {
 
         cryptoInitOk = false;
         if (!isFingerprintInitialized()) {
@@ -228,13 +233,13 @@ public class FingerPrintHelper {
             return;
         }
         try {
-            initDecryptKey(ivSpecValue,false);
+            initDecryptKey(ivSpecValue,false, startListening);
         } catch (final InvalidKeyException invalidKeyException) {
             // Key was invalidated (maybe all registered fingerprints were changed)
             // Retry with new key
             try {
                 fingerPrintCallback.onKeyInvalidated();
-                initDecryptKey(ivSpecValue, true);
+                initDecryptKey(ivSpecValue, true, startListening);
             } catch (InvalidKeyException e) {
                 fingerPrintCallback.onInvalidKeyException();
             } catch (Exception e) {
@@ -245,8 +250,10 @@ public class FingerPrintHelper {
         }
     }
 
-    private void initDecryptKey(final String ivSpecValue, boolean deleteExistingKey)
-            throws  Exception {
+    private void initDecryptKey(
+            final String ivSpecValue,
+            final boolean deleteExistingKey,
+            final boolean startListening) throws  Exception {
 
         createNewKeyIfNeeded(deleteExistingKey);
         keyStore.load(null);
@@ -259,7 +266,7 @@ public class FingerPrintHelper {
         cryptoInitOk = true;
 
         stopListening();
-        startListening();
+        if( startListening ) startListening();
     }
 
     public void decryptData(final String encryptedValue) {

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -169,7 +169,10 @@
     <string name="warning_read_only">Uw sd-card is mementeel niet beschrijfbaar. U zult wijzigingen in de database niet kunnen opslaan.</string>
     <string name="warning_unmounted">Uw sd-card is momenteel ontkoppeld. U zult geen database kunnen openen of aanmaken.</string>
     <string name="version_label">Versie:</string>
-    
+    <string name="fingerprint_autoscan">Activeer automatisch scannen van vingerafdruk bij het openen van een bestand. Deze optie kun je uitschakelen wanneer dit problemen oplevert.</string>
+    <string name="fingerprint_autoscan_title">Automatisch scannen van vingerafdruk</string>
+
+
     <string-array name="clipboard_timeout_options">
      <item>30 seconden</item>
     	<item>1 minuut</item>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -171,7 +171,7 @@
     <string name="version_label">Versie:</string>
     <string name="fingerprint_autoscan">Activeer automatisch scannen van vingerafdruk bij het openen van een bestand. Deze optie kun je uitschakelen wanneer dit problemen oplevert.</string>
     <string name="fingerprint_autoscan_title">Automatisch scannen van vingerafdruk</string>
-
+    <string name="fingerprint_autoscan_hint">Automatisch scannen vingerafdruk niet actief</string>
 
     <string-array name="clipboard_timeout_options">
      <item>30 seconden</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -60,6 +60,7 @@
     <bool name="recentfile_default">true</bool>
     <bool name="saf_default">false</bool>
     <bool name="fingerprint_autoscan">true</bool>
+    <string name="fingerprint_autoscan_key">fingerprint_autoscan_key</string>
     
     <string name="clipboard_timeout_default">300000</string>
     <string-array name="clipboard_timeout_values">

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -59,6 +59,7 @@
     <bool name="omitbackup_default">true</bool>
     <bool name="recentfile_default">true</bool>
     <bool name="saf_default">false</bool>
+    <bool name="fingerprint_autoscan">true</bool>
     
     <string name="clipboard_timeout_default">300000</string>
     <string-array name="clipboard_timeout_values">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,7 @@
     <string name="no_external_permissions">Permission to read and write external storage was denied</string>
     <string name="fingerprint_autoscan">Allow automatically scanning for fingerprints when opening file. Disable this option if fingerprint scanning causes issues.</string>
     <string name="fingerprint_autoscan_title">Enable fingerprint scanning</string>
+    <string name="fingerprint_autoscan_hint">Auto fingerprint scanning not enabled</string>
 
     <string-array name="clipboard_timeout_options">
     	<item>30 seconds</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,6 +206,8 @@
     <string name="fingerprint_notrecognized">Fingerprint not recognized</string>
     <string name="fingerprint_key_invalidated">Stored password no longer valid. Re-enter password</string>
     <string name="no_external_permissions">Permission to read and write external storage was denied</string>
+    <string name="fingerprint_autoscan">Allow automatically scanning for fingerprints when opening file. Disable this option if fingerprint scanning causes issues.</string>
+    <string name="fingerprint_autoscan_title">Enable fingerprint scanning</string>
 
     <string-array name="clipboard_timeout_options">
     	<item>30 seconds</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -98,6 +98,6 @@
 			android:summary="@string/fingerprint_autoscan"
 			android:defaultValue="@bool/fingerprint_autoscan"
 			android:title="@string/fingerprint_autoscan_title"
-			android:key="@string/fingerprint_autoscan"/>
+			android:key="@string/fingerprint_autoscan_key"/>
 	</PreferenceScreen>
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -94,5 +94,10 @@
 			android:summary="@string/rounds_fix_explaination"
 			android:numeric="integer"
 			android:title="@string/rounds_fix"/>
+		<CheckBoxPreference
+			android:summary="@string/fingerprint_autoscan"
+			android:defaultValue="@bool/fingerprint_autoscan"
+			android:title="@string/fingerprint_autoscan_title"
+			android:key="@string/fingerprint_autoscan"/>
 	</PreferenceScreen>
 </PreferenceScreen>


### PR DESCRIPTION
fixes the issue that One Plus 6T users have with in screen fingerprint sensors that overlap the keyboard. Check issue for a screenshot of the actual issue. 

Now there is an extra preference where you can disable the automatic start of fingerprint scanning. That way these users can disable it and only enable it again on hitting the fingerprint icon next to the password input field. 

It's enabled by default (the automatic scanning) so minimal impact towards existing users that have no issues with the fingerprint scanning. 