### PR TITLE
Prevent JUnit from being transitively included in the APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,9 @@ dependencies {
     androidTestImplementation files('libs/junit4.jar')
 
     implementation 'com.madgag.spongycastle:core:1.58.0.0'
-    implementation 'com.madgag.spongycastle:prov:1.58.0.0'
+    implementation ('com.madgag.spongycastle:prov:1.58.0.0') {
+        exclude group: 'junit'
+    }
     implementation 'joda-time:joda-time:2.9.4'
     implementation 'com.android.support:support-compat:27.1.1'
     implementation 'org.apache.commons:commons-io:1.3.2'


### PR DESCRIPTION
I noticed that release APK contains JUnit framework.
`./gradlew app:dependencies` reveals that JUnit gets included in the release APK as dependency of `com.madgag.spongycastle:prov`.
